### PR TITLE
docs: add app deployment templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,25 @@ Security defaults: restricted Pod Security and default-deny NetworkPolicy.
 
 ```
 Project -> App -> Release
-         |            
+         |
          -> Plugins (capabilities)
 ```
+
+## Templates
+
+Ready-made Kubernetes manifests are available in the [templates](templates/) directory to help you bootstrap apps quickly. The structure keeps configuration organized and can be adopted by GitOps tools like Flux in the future.
+
+```
+templates
+├── bootstrap
+│   ├── helmrepositories
+│   │   └── helmrepository-podinfo.yaml
+│   └── namespaces
+│       └── namespace-podinfo.yaml
+└── podinfo
+    ├── configmap-podinfo-helm-chart-value-overrides.yaml
+    └── helmrelease-podinfo.yaml
+```
+
+Copy these templates and adjust them for your own applications.
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,16 @@
+# Templates
+
+Ready-made templates to help you structure Kubernetes configuration for Slipway applications. Copy this directory into your own Git repository and customize it for your needs.
+
+```
+├── bootstrap
+│   ├── helmrepositories
+│   │   └── helmrepository-podinfo.yaml
+│   └── namespaces
+│       └── namespace-podinfo.yaml
+└── podinfo
+    ├── configmap-podinfo-helm-chart-value-overrides.yaml
+    └── helmrelease-podinfo.yaml
+```
+
+These templates are generic and not tied to any specific GitOps tool, but they can be consumed by systems like Flux if desired.

--- a/templates/bootstrap/helmrepositories/helmrepository-podinfo.yaml
+++ b/templates/bootstrap/helmrepositories/helmrepository-podinfo.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: podinfo
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://stefanprodan.github.io/podinfo

--- a/templates/bootstrap/namespaces/namespace-podinfo.yaml
+++ b/templates/bootstrap/namespaces/namespace-podinfo.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: podinfo

--- a/templates/podinfo/configmap-podinfo-helm-chart-value-overrides.yaml
+++ b/templates/podinfo/configmap-podinfo-helm-chart-value-overrides.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: podinfo-values
+  namespace: podinfo
+data:
+  values.yaml: |
+    replicaCount: 1

--- a/templates/podinfo/helmrelease-podinfo.yaml
+++ b/templates/podinfo/helmrelease-podinfo.yaml
@@ -1,0 +1,18 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: podinfo
+  namespace: podinfo
+spec:
+  chart:
+    spec:
+      chart: podinfo
+      sourceRef:
+        kind: HelmRepository
+        name: podinfo
+        namespace: flux-system
+  interval: 5m
+  valuesFrom:
+    - kind: ConfigMap
+      name: podinfo-values
+      valuesKey: values.yaml


### PR DESCRIPTION
## Summary
- add templates directory with example Kubernetes manifests
- document template usage and layout in README

## Testing
- `go test ./...` (hung, manually interrupted)

------
https://chatgpt.com/codex/tasks/task_e_689895866dc48323a216aa552e60ef9d